### PR TITLE
fix crux-rename-file-and-buffer function name

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -188,7 +188,7 @@ point reaches the beginning or end of the buffer, stop there."
     (setq end (line-end-position))
     (cons beg end)))
 
-(defun crux-rename-buffer-and-file ()
+(defun crux-rename-file-and-buffer ()
   "Rename current buffer and if the buffer is visiting a file, rename it too."
   (interactive)
   (let ((filename (buffer-file-name)))


### PR DESCRIPTION
the function name does not refer to the one on the doc.
Renamed the function instead of the the doc, seemed more uniform to the other function names, than renaming the doc instead