### PR TITLE
Support tcsh, fish and ksh for crux-find-shell-init-file.

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -350,6 +350,9 @@ Doesn't mess with special buffers."
          (shell-init-file (cond
                            ((string= "zsh" shell) ".zshrc")
                            ((string= "bash" shell) ".bashrc")
+                           ((string= "tcsh" shell) ".login")
+                           ((string= "fish" shell) ".config/fish/config.fish")
+                           ((string-prefix-p "ksh" shell) ".profile")
                            (t (error "Unknown shell")))))
     (find-file-other-window (expand-file-name shell-init-file (getenv "HOME")))))
 


### PR DESCRIPTION
There are still improvements that can be done: 1. Select one of the startup files before open. See http://hyperpolyglot.org/unix-shells#startup-file. 2. Detect shell when the shell is something like /usr/bin/sh.

The string-prefix-p for ksh is due to various names of ksh in different distributions such as ksh88 and ksh93