### PR TITLE
Require tramp for `tramp-tramp-file-p`.

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -36,6 +36,7 @@
 
 (require 'thingatpt)
 (require 'seq)
+(require 'tramp)
 
 (defgroup crux nil
   "crux configuration."


### PR DESCRIPTION
Or it complains 'crux-reopen-as-root: Symbol's function definition is void: tramp-tramp-file-p'.
There is still another way to fix this:
```
(declare-function tramp-tramp-file-p "ext:tramp")
replace (tramp-tramp-file-p buffer-file-name) with (when (require 'tramp nil 'noerror) (tramp-tramp-file-p buffer-file-name))
```
Not sure which way is better. You do the decision.