### PR TITLE
Add crux-transpose-windows for swapping the buffers between two windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Command                                     | Suggested Keybinding(s)         | 
 `crux-view-url`                             | <kbd>C-c u</kbd> | Open a new buffer containing the contents of URL.
 `crux-eval-and-replace`                     | <kbd>C-c e</kbd> | Eval a bit of Emacs Lisp code and replace it with its result.
 `crux-swap-windows`                         | <kbd>C-c s</kbd> | Swap two active windows.
+`crux-tranpose-windows`                     | <kbd>C-x 4 t</kbd> | Transpose the buffers between two windows.
 `crux-delete-file-and-buffer`               | <kbd>C-c D</kbd> | Delete current file and buffer.
 `crux-rename-file-and-buffer`               | <kbd>C-c r</kbd> | Rename the current buffer and its visiting file if any.
 `crux-visit-term-buffer`                    | <kbd>C-c t</kbd> | Open a terminal emulator (`ansi-term`).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Command                                     | Suggested Keybinding(s)         | 
 `crux-recentf-ido-find-file`                | <kbd>C-c f</kbd> or <kbd>Super-r</kbd> | Open recently visited file.
 `crux-view-url`                             | <kbd>C-c u</kbd> | Open a new buffer containing the contents of URL.
 `crux-eval-and-replace`                     | <kbd>C-c e</kbd> | Eval a bit of Emacs Lisp code and replace it with its result.
-`crux-swap-windows`                         | <kbd>C-c s</kbd> | Swap two active windows.
 `crux-tranpose-windows`                     | <kbd>C-x 4 t</kbd> | Transpose the buffers between two windows.
 `crux-delete-file-and-buffer`               | <kbd>C-c D</kbd> | Delete current file and buffer.
 `crux-rename-file-and-buffer`               | <kbd>C-c r</kbd> | Rename the current buffer and its visiting file if any.

--- a/crux.el
+++ b/crux.el
@@ -346,6 +346,22 @@ buffer is not visiting a file."
       (set-window-start w2 s1)))
   (other-window 1))
 
+;; modified from https://www.emacswiki.org/emacs/TransposeWindows
+(defun crux-transpose-windows (arg)
+  "Transpose the buffers shown in two windows.
+Prefix ARG determines if the current windows buffer is swapped
+with the next or previous window, and the number of
+transpositions to execute in sequence."
+  (interactive "p")
+  (let ((selector (if (>= arg 0) 'next-window 'previous-window)))
+    (while (/= arg 0)
+      (let ((this-win (window-buffer))
+            (next-win (window-buffer (funcall selector))))
+        (set-window-buffer (selected-window) next-win)
+        (set-window-buffer (funcall selector) this-win)
+        (select-window (funcall selector)))
+      (setq arg (if (cl-plusp arg) (1- arg) (1+ arg))))))
+
 (defun crux-switch-to-previous-buffer ()
   "Switch to previously open buffer.
 Repeated invocations toggle between the two most recently open buffers."

--- a/crux.el
+++ b/crux.el
@@ -329,23 +329,6 @@ buffer is not visiting a file."
     (when file
       (find-file file))))
 
-(defun crux-swap-windows ()
-  "If you have 2 windows, it swaps them."
-  (interactive)
-  (if (/= (count-windows) 2)
-      (message "You need exactly 2 windows to do this.")
-    (let* ((w1 (car (window-list)))
-           (w2 (cadr (window-list)))
-           (b1 (window-buffer w1))
-           (b2 (window-buffer w2))
-           (s1 (window-start w1))
-           (s2 (window-start w2)))
-      (set-window-buffer w1 b2)
-      (set-window-buffer w2 b1)
-      (set-window-start w1 s2)
-      (set-window-start w2 s1)))
-  (other-window 1))
-
 ;; modified from https://www.emacswiki.org/emacs/TransposeWindows
 (defun crux-transpose-windows (arg)
   "Transpose the buffers shown in two windows.
@@ -361,6 +344,8 @@ transpositions to execute in sequence."
         (set-window-buffer (funcall selector) this-win)
         (select-window (funcall selector)))
       (setq arg (if (cl-plusp arg) (1- arg) (1+ arg))))))
+
+(defalias 'crux-swap-windows 'crux-transpose-windows)
 
 (defun crux-switch-to-previous-buffer ()
   "Switch to previously open buffer.


### PR DESCRIPTION
This is copied directly from
https://www.emacswiki.org/emacs/TransposeWindows, and renamed to
crux-tranpose-windows. The wiki page mentions the original author as
Thomas Bellman. It does not appear to be published in any existing
package that I could find.