### PR TITLE
Don't change default find-file behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ current line, rather than the whole line, in the absence of a region:
 (crux-with-region-or-point-to-eol kill-ring-save)
 ```
 
+## Minor modes
+
+#### `(crux-reopen-as-root-mode)` ####
+
+Crux provides a `crux-reopen-as-root` command for reopening a file as
+root. This global minor mode changes `find-file` so all root files are
+automatically opened as root.
+
 ## License
 
 Copyright © 2015 Bozhidar Batsov and [contributors][].

--- a/crux.el
+++ b/crux.el
@@ -313,7 +313,14 @@ buffer is not visiting a file."
               (crux-file-owned-by-user-p buffer-file-name))
     (crux-find-alternate-file-as-root buffer-file-name)))
 
-(add-hook 'find-file-hook #'crux-reopen-as-root)
+;;;###autoload
+(define-minor-mode crux-reopen-as-root-mode
+  "Automatically reopen files as root if we can't write to them
+as the current user."
+  :global t
+  (if crux-reopen-as-root-mode
+      (add-hook 'find-file-hook #'crux-reopen-as-root)
+    (remove-hook 'find-file-hook #'crux-reopen-as-root)))
 
 (defun crux-insert-date ()
   "Insert a timestamp according to locale's date and time format."


### PR DESCRIPTION
Currently, opening any file that is read-only and not owned by the
current user triggers a root login prompt. This occurs for viewing
system files (e.g /etc/fstab), built-in elisp
libraries (e.g. simple.el.gz) and simply viewing files owned by other
users on a shared system.

We can't assume that this is the behaviour users want, and changing
built-in functions without asking is surprising.

Fixes #20.