### PR TITLE
Increase flexibility for inputs to crux-rename-file-and-buffer

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -232,7 +232,9 @@ point reaches the beginning or end of the buffer, stop there."
   (let ((filename (buffer-file-name)))
     (if (not (and filename (file-exists-p filename)))
         (rename-buffer (read-from-minibuffer "New name: " (buffer-name)))
-      (let ((new-name (read-from-minibuffer "New name: " filename)))
+      (let* ((new-name (read-from-minibuffer "New name: " filename))
+             (containing-dir (file-name-directory new-name)))
+        (make-directory containing-dir t)
         (cond
          ((vc-backend filename) (vc-rename-file filename new-name))
          (t

--- a/crux.el
+++ b/crux.el
@@ -232,7 +232,7 @@ point reaches the beginning or end of the buffer, stop there."
   (let ((filename (buffer-file-name)))
     (if (not (and filename (file-exists-p filename)))
         (rename-buffer (read-from-minibuffer "New name: " (buffer-name)))
-      (let ((new-name (read-file-name "New name: " filename)))
+      (let ((new-name (read-from-minibuffer "New name: " filename)))
         (cond
          ((vc-backend filename) (vc-rename-file filename new-name))
          (t


### PR DESCRIPTION
This changes `crux-rename-file-and-buffer` to:

* Let users specify new file names, even if ido/helm are enabled
* Let users create new directories by modifying other parts of the path

Let me know what you think. These are the only features my implementation has when I realised that crux can do this for me. I've separated these two changes into two commits in case you'd prefer only having one of these changes.