### PR TITLE
Fix malformed header line

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -1,4 +1,4 @@
-;;; crux --- A Collection of Ridiculously Useful eXtensions -*- lexical-binding: t -*-
+;;; crux.el --- A Collection of Ridiculously Useful eXtensions -*- lexical-binding: t -*-
 ;;
 ;; Copyright © 2015-2016 Bozhidar Batsov
 ;;


### PR DESCRIPTION
This was preventing `package.el` (and hence MELPA) from parsing the package metadata.