### PR TITLE
Use synchronous process for crux-open-with

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -97,7 +97,7 @@ With a prefix ARG always prompt for command to use."
          (program (if (or arg (not open))
                       (read-shell-command "Open current file with: ")
                     open)))
-    (start-process "crux-open-with-process" nil program current-file-name)))
+    (call-process program nil 0 nil current-file-name)))
 
 (defun crux-buffer-mode (buffer-or-name)
   "Retrieve the `major-mode' of BUFFER-OR-NAME."


### PR DESCRIPTION
Since the system open command appears to fork immediately there shouldn't be any
real performance penalty to doing this.

Fixes #37 

@bbatsov Please test on OSX. I'm not able to.