### PR TITLE
Add smart kill line function

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ individual commands to whatever keybindings you prefer.
 Command                                             | Suggested Keybinding(s)         | Description
 ----------------------------------------------------|---------------------------------|------------------------
 `crux-open-with`                                    | <kbd>C-c o</kbd>   | Open the currently visited file with an external program.
+`crux-smart-kill-line`                              | <kbd>C-k</kbd> or <kbd>Super-k</kbd> | First kill to end of line, then kill the whole line.
 `crux-smart-open-line-above`                        | <kbd>C-S-RET</kbd> or <kbd>Super-o</kbd> | Insert an empty line above the current line and indent it properly.
 `crux-smart-open-line`                              | <kbd>S-RET</kbd> or <kbd>M-o</kbd> | Insert an empty line and indent it properly (as in most IDEs).
 `crux-cleanup-buffer-or-region`                     | <kbd>C-c n</kbd> | Fix indentation in buffer and strip whitespace.

--- a/crux.el
+++ b/crux.el
@@ -174,6 +174,19 @@ With a prefix ARG open line above the current line."
       (move-end-of-line nil)
       (newline-and-indent))))
 
+(defun crux-smart-kill-line (arg)
+  "Kill to the end of the line and kill whole line on the next call"
+  (interactive "P")
+  (let ((orig-point (point)))
+    (move-end-of-line 1)
+    (if (= orig-point (point))
+        (crux-kill-whole-line)
+      (progn
+        (goto-char orig-point)
+        (kill-line))
+      )))
+
+
 (defun crux-top-join-line ()
   "Join the current line with the line beneath it."
   (interactive)


### PR DESCRIPTION
Similar to `crux-move-beginning-of-line` in that it behaves differently if you press it twice.

I find it super handy and thought I would offer to share it.

### Open question:

I suggest overriding the default `C-k` command with smart-kill-line since the behavior is similar enough I don't miss the default. Do we have a preference about that? I can't think of a better suggested keybinding.