### PR TITLE
Beginning line function

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -156,7 +156,7 @@ Position the cursor at its beginning, according to the current mode."
   (if electric-indent-inhibit
       ;; We can't use `indent-according-to-mode' in languages like Python,
       ;; as there are multiple possible indentations with different meanings.
-      (let* ((indent-end (progn (move-to-smart-line-start) (point)))
+      (let* ((indent-end (progn (move-to-mode-line-start) (point)))
              (indent-start (progn (move-beginning-of-line nil) (point)))
              (indent-chars (buffer-substring indent-start indent-end)))
         (forward-line -1)
@@ -203,7 +203,7 @@ With a prefix ARG open line above the current line."
 Passes ARG to command `kill-whole-line' when provided."
   (interactive "p")
   (kill-whole-line arg)
-  (move-to-smart-line-start))
+  (move-to-mode-line-start))
 
 (defun crux-kill-line-backwards ()
   "Kill line backwards and adjust the indentation."
@@ -211,20 +211,14 @@ Passes ARG to command `kill-whole-line' when provided."
   (kill-line 0)
   (indent-according-to-mode))
 
-
-(defvar crux-smart-line-start-regex "^[[:space:]]*"
-  "Regex to match pre-line text.
-Matches whitespace in nearly all major modes.  Matches the terminal prompts
- in 'ansi-term' and 'eshell.")
-(add-hook 'term-mode-hook   (lambda () (setq crux-smart-line-start-regex "^[^#$%>\n]*[#$%>] " )))
-(add-hook 'eshell-mode-hook (lambda () (setq crux-smart-line-start-regex "^[^$\n]*$ ")))
-
-(defun move-to-smart-line-start ()
-  "Move to the beginning, skipping crux-smart-line-start-regex match."
+(defun move-to-mode-line-start ()
+  "Move to the beginning, skipping mode specific line start regex."
   (interactive)
   (move-beginning-of-line nil)
-  (search-forward-regexp crux-smart-line-start-regex))
-
+  (let ((line-start-regex (cond ((eq major-mode 'term-mode) "^[^#$%>\n]*[#$%>] ")
+                                ((eq major-mode 'eshell-mode) "^[^$\n]*$ ")
+                                (t "^[[:space:]]*"))))
+    (search-forward-regexp line-start-regex)))
 
 
 (defun crux-move-beginning-of-line (arg)
@@ -246,7 +240,7 @@ point reaches the beginning or end of the buffer, stop there."
       (forward-line (1- arg))))
 
   (let ((orig-point (point)))
-    (move-to-smart-line-start)
+    (move-to-mode-line-start)
     (when (= orig-point (point))
       (move-beginning-of-line 1))))
 

--- a/crux.el
+++ b/crux.el
@@ -220,7 +220,7 @@ Matches whitespace in nearly all major modes.  Matches the terminal prompts
 (add-hook 'eshell-mode-hook (lambda () (setq crux-smart-line-start-regex "^[^$\n]*$ ")))
 
 (defun move-to-smart-line-start ()
-  "Move to the beginning, skipping crux-smart-line-start-regexd match."
+  "Move to the beginning, skipping crux-smart-line-start-regex match."
   (interactive)
   (move-beginning-of-line nil)
   (search-forward-regexp crux-smart-line-start-regex))

--- a/crux.el
+++ b/crux.el
@@ -211,13 +211,26 @@ Passes ARG to command `kill-whole-line' when provided."
   (kill-line 0)
   (indent-according-to-mode))
 
+(defvar crux-line-start-regex-term-mode "^[^#$%>\n]*[#$%>] "
+  "Match terminal prompts.
+
+Used by crux functions like crux-move-beginning-of-line to skip over the prompt")
+
+(defvar crux-line-start-regex-eshell-mode "^[^$\n]*$ " "Match eshell prompt.
+
+Used by crux functions like crux-move-beginning-of-line to skip over the prompt")
+
+(defvar crux-line-start-regex "^[[:space:]]*" "Match whitespace in from of line.
+
+Used by crux functions like crux-move-beginning-of-line to skip over whitespace")
+
 (defun move-to-mode-line-start ()
   "Move to the beginning, skipping mode specific line start regex."
   (interactive)
   (move-beginning-of-line nil)
-  (let ((line-start-regex (cond ((eq major-mode 'term-mode) "^[^#$%>\n]*[#$%>] ")
-                                ((eq major-mode 'eshell-mode) "^[^$\n]*$ ")
-                                (t "^[[:space:]]*"))))
+  (let ((line-start-regex (cond ((eq major-mode 'term-mode) crux-line-start-regex-term-mode)
+                                ((eq major-mode 'eshell-mode) crux-line-start-regex-eshell-mode)
+                                (t crux-line-start-regex))))
     (search-forward-regexp line-start-regex)))
 
 

--- a/crux.el
+++ b/crux.el
@@ -212,14 +212,15 @@ Passes ARG to command `kill-whole-line' when provided."
   (indent-according-to-mode))
 
 
-(defvar crux-smart-line-start-regex "^[[:space:]]*" "Regex to match pre-line text.
+(defvar crux-smart-line-start-regex "^[[:space:]]*"
+  "Regex to match pre-line text.
 Matches whitespace in nearly all major modes.  Matches the terminal prompts
  in 'ansi-term' and 'eshell.")
 (add-hook 'term-mode-hook   (lambda () (setq crux-smart-line-start-regex "^[^#$%>\n]*[#$%>] " )))
 (add-hook 'eshell-mode-hook (lambda () (setq crux-smart-line-start-regex "^[^$\n]*$ ")))
 
 (defun move-to-smart-line-start ()
-  "Move to the beginning, skipping whitespace or terminal prompts if found."
+  "Move to the beginning, skipping crux-smart-line-start-regexd match."
   (interactive)
   (move-beginning-of-line nil)
   (search-forward-regexp crux-smart-line-start-regex))

--- a/crux.el
+++ b/crux.el
@@ -156,7 +156,7 @@ Position the cursor at its beginning, according to the current mode."
   (if electric-indent-inhibit
       ;; We can't use `indent-according-to-mode' in languages like Python,
       ;; as there are multiple possible indentations with different meanings.
-      (let* ((indent-end (progn (back-to-indentation) (point)))
+      (let* ((indent-end (progn (move-to-smart-line-start) (point)))
              (indent-start (progn (move-beginning-of-line nil) (point)))
              (indent-chars (buffer-substring indent-start indent-end)))
         (forward-line -1)
@@ -203,13 +203,28 @@ With a prefix ARG open line above the current line."
 Passes ARG to command `kill-whole-line' when provided."
   (interactive "p")
   (kill-whole-line arg)
-  (back-to-indentation))
+  (move-to-smart-line-start))
 
 (defun crux-kill-line-backwards ()
   "Kill line backwards and adjust the indentation."
   (interactive)
   (kill-line 0)
   (indent-according-to-mode))
+
+
+(defvar crux-smart-line-start-regex "^[[:space:]]*" "Regex to match pre-line text.
+Matches whitespace in nearly all major modes.  Matches the terminal prompts
+ in 'ansi-term' and 'eshell.")
+(add-hook 'term-mode-hook   (lambda () (setq crux-smart-line-start-regex "^[^#$%>\n]*[#$%>] " )))
+(add-hook 'eshell-mode-hook (lambda () (setq crux-smart-line-start-regex "^[^$\n]*$ ")))
+
+(defun move-to-smart-line-start ()
+  "Move to the beginning, skipping whitespace or terminal prompts if found."
+  (interactive)
+  (move-beginning-of-line nil)
+  (search-forward-regexp crux-smart-line-start-regex))
+
+
 
 (defun crux-move-beginning-of-line (arg)
   "Move point back to indentation of beginning of line.
@@ -230,7 +245,7 @@ point reaches the beginning or end of the buffer, stop there."
       (forward-line (1- arg))))
 
   (let ((orig-point (point)))
-    (back-to-indentation)
+    (move-to-smart-line-start)
     (when (= orig-point (point))
       (move-beginning-of-line 1))))
 


### PR DESCRIPTION
Defines crux-smart-line-start, a new function to replace back-to-indentation.

back-to-indentation moves the point to the first non-whitespace character. The new function does that for all major modes, except ansi-term and eshell, where it moves to end of the prompt. More major modes can be added.

By fixing this function, crux-move-beginning-of-line is improved. [Prelude issue #998](https://github.com/bbatsov/prelude/issues/998) "C-a broken in eshell" is fixed. There were workarounds posted in that thread, but I thought a better solution was available.