### PR TITLE
Fixes two issues with crux-move-beginning-line

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -231,7 +231,7 @@ Used by crux functions like crux-move-beginning-of-line to skip over whitespace"
   (let ((line-start-regex (cond ((eq major-mode 'term-mode) crux-line-start-regex-term-mode)
                                 ((eq major-mode 'eshell-mode) crux-line-start-regex-eshell-mode)
                                 (t crux-line-start-regex))))
-    (search-forward-regexp line-start-regex)))
+    (search-forward-regexp line-start-regex (line-end-position) t)))
 
 
 (defun crux-move-beginning-of-line (arg)


### PR DESCRIPTION
Fixes issues described in https://github.com/bbatsov/crux/issues/46

(line-end-position) stops the search from passing through all the
empty lines.

t suppresses the message on search fail, but doesn't move to the line
end. A non nil, non t arg would also suppress the message, but move
to (line-end-position).