### PR TITLE
crux-eval-and-replace: insert literal s-exp instead of printing.

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -365,7 +365,7 @@ point reaches the beginning or end of the buffer, stop there."
   (interactive)
   (let ((value (eval (elisp--preceding-sexp))))
     (backward-kill-sexp)
-    (insert (format "%s" value))))
+    (insert (format "%S" value))))
 
 (defun crux-recompile-init ()
   "Byte-compile all your dotfiles again."


### PR DESCRIPTION
This makes it so that the sexp is replaced with the actual value. Otherwise, you get a printed version that isn't actually that useful in elisp.