### PR TITLE
Saner functions for modifying cases on region for humans

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Command                                             | Suggested Keybinding(s)   
 `crux-kill-whole-line`                              | <kbd>Super-k</kbd> | Kill whole line
 `crux-kill-line-backwards`                          | <kbd>C-Backspace</kbd> | Kill line backwards
 `crux-ispell-word-then-abbrev`                      | <kbd>C-c i</kbd> | Fix word using `ispell` and then save to `abbrev`.
+`crux-upcase-region`                                | <kbd>C-x C-u</kbd> | `upcase-region` when `transient-mark-mode` is on and region is active.
+`crux-downcase-region`                              | <kbd>C-x C-l</kbd> | `downcase-region` when `transient-mark-mode` is on and region is active.
+`crux-capitalize-region`                            | <kbd>C-x M-c</kbd> | `capitalize-region` when `transient-mark-mode` is on and region is active.
 
 Here's how you'd bind some of the commands to keycombos:
 

--- a/crux.el
+++ b/crux.el
@@ -582,6 +582,27 @@ Doesn't mess with special buffers."
         (find-file-other-window (completing-read "Choose shell init file: " candidates))
       (find-file-other-window (car candidates)))))
 
+;;;###autoload
+(defun crux-upcase-region (beg end)
+  "`upcase-region' when `transient-mark-mode' is on and region is active."
+  (interactive "*r")
+  (when (use-region-p)
+    (upcase-region beg end)))
+
+;;;###autoload
+(defun crux-downcase-region (beg end)
+  "`downcase-region' when `transient-mark-mode' is on and region is active."
+  (interactive "*r")
+  (when (use-region-p)
+    (downcase-region beg end)))
+
+;;;###autoload
+(defun crux-capitalize-region (beg end)
+  "`capitalize-region' when `transient-mark-mode' is on and region is active."
+  (interactive "*r")
+  (when (use-region-p)
+    (capitalize-region beg end)))
+
 ;; http://endlessparentheses.com/ispell-and-abbrev-the-perfect-auto-correct.html
 ;;;###autoload
 (defun crux-ispell-word-then-abbrev (p)


### PR DESCRIPTION
(I promise this is the last of my barrage of PRs)

By default `upcase-region` `downcase-region` and `captialize-region` commands
are disabled in emacs, and for good reason because they are insane. Whenever
you've placed a mark anywhere in the document, inadventently pressing one of the
assigned keybinding will change the cases for all the words in half a
document. These commands resurrect these potentially useful functions in a much
saner way by wrapping them around `use-region-p`, so they are only activated
when `transient-mark-mode` is one.