### PR TITLE
Use `beginning-of-visual-line' in `move-to-mode-line-start'

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -135,6 +135,12 @@ expected name of the shell buffer."
   :type 'symbol
   :group 'crux)
 
+(defcustom crux-should-move-visually
+  nil
+  "Wheter moves should take visual lines into account or not."
+  :type 'boolean
+  :group 'crux)
+
 (defun crux-ansi-term (buffer-name)
   "Use ansi-term for `crux-visit-term-buffer'"
   (ansi-term crux-shell buffer-name))
@@ -307,7 +313,11 @@ Deletes whitespace at join."
 (defun move-to-mode-line-start ()
   "Move to the beginning, skipping mode specific line start regex."
   (interactive)
-  (move-beginning-of-line nil)
+
+  (if crux-should-move-visually
+      (beginning-of-visual-line nil)
+    (move-beginning-of-line nil))
+
   (let ((line-start-regex (cdr (seq-find
                                 (lambda (e) (derived-mode-p (car e)))
                                 crux-line-start-regex-alist


### PR DESCRIPTION
This way, functions such as `crux-move-beginning-of-line' work as expected when in visual-line mode:

1. If the user runs this function in the middle of a visual line, it will go to the beginning of said visual line.
2. If the user runs this function again, then it will go to the beginning of the real line.
3. If the user runs this function again, then it will go to the first non-space character of the line.

Swapping 2 and 3 may also be an expected behavior but then the code became way more complicated than it should.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>