### PR TITLE
Add function crux-kill-and-join-forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Command                                             | Suggested Keybinding(s)   
 `crux-top-join-line`                                | <kbd>Super-j</kbd> or <kbd>C-^</kbd> | Join lines
 `crux-kill-whole-line`                              | <kbd>Super-k</kbd> | Kill whole line
 `crux-kill-line-backwards`                          | <kbd>C-Backspace</kbd> | Kill line backwards
+`crux-kill-and-join-forward`                        | <kbd>C-S-Backspace</kbd> or <kbd>C-k</kbd> | If at end of line, join with following; otherwise kill line.
 `crux-ispell-word-then-abbrev`                      | <kbd>C-c i</kbd> | Fix word using `ispell` and then save to `abbrev`.
 `crux-upcase-region`                                | <kbd>C-x C-u</kbd> | `upcase-region` when `transient-mark-mode` is on and region is active.
 `crux-downcase-region`                              | <kbd>C-x C-l</kbd> | `downcase-region` when `transient-mark-mode` is on and region is active.

--- a/crux.el
+++ b/crux.el
@@ -294,6 +294,16 @@ Passes ARG to command `kill-whole-line' when provided."
   (kill-line 0)
   (indent-according-to-mode))
 
+;;;###autoload
+(defun crux-kill-and-join-forward (&optional arg)
+  "If at end of line, join with following; otherwise kill line.
+Passes ARG to command `kill-line' when provided.
+Deletes whitespace at join."
+  (interactive "P")
+  (if (and (eolp) (not (bolp)))
+      (delete-indentation 1)
+    (kill-line arg)))
+
 (defun move-to-mode-line-start ()
   "Move to the beginning, skipping mode specific line start regex."
   (interactive)


### PR DESCRIPTION
This is complementary to crux-kill-line-backwards, but moving forward,
and when called at end of line, it will join.