### PR TITLE
Add crux-kill-buffer-truename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#65](https://github.com/bbatsov/crux/pull/65): Add a configuration option to move using visual lines in `crux-move-to-mode-line-start`.
+* [#72](https://github.com/bbatsov/crux/pull/72): Add `crux-kill-buffer-truename`. Kills path of file visited by current buffer.
 
 ### Bugs fixed
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Command                                             | Suggested Keybinding(s)   
 `crux-kill-whole-line`                              | <kbd>Super-k</kbd> | Kill whole line
 `crux-kill-line-backwards`                          | <kbd>C-Backspace</kbd> | Kill line backwards
 `crux-kill-and-join-forward`                        | <kbd>C-S-Backspace</kbd> or <kbd>C-k</kbd> | If at end of line, join with following; otherwise kill line.
+`crux-kill-buffer-truename `                        | <kbd>C-c P</kbd> | Kill absolute path of file visited in current buffer.
 `crux-ispell-word-then-abbrev`                      | <kbd>C-c i</kbd> | Fix word using `ispell` and then save to `abbrev`.
 `crux-upcase-region`                                | <kbd>C-x C-u</kbd> | `upcase-region` when `transient-mark-mode` is on and region is active.
 `crux-downcase-region`                              | <kbd>C-x C-l</kbd> | `downcase-region` when `transient-mark-mode` is on and region is active.

--- a/crux.el
+++ b/crux.el
@@ -661,6 +661,16 @@ Doesn't mess with special buffers."
      (delete (current-buffer) (seq-filter #'buffer-file-name (buffer-list))))))
 
 ;;;###autoload
+(defun crux-kill-buffer-truename ()
+  "Kill absolute path of file visited in current buffer."
+  (interactive)
+  (if buffer-file-name
+      (let ((truename (file-truename buffer-file-name)))
+        (kill-new truename)
+        (message "Added %s to kill ring." truename))
+    (message "Buffer is not visiting a file.")))
+
+;;;###autoload
 (defun crux-create-scratch-buffer ()
   "Create a new scratch buffer."
   (interactive)


### PR DESCRIPTION
Make it easy to kill the path of file visited in the current buffer. I was able to replace most of my own functions with a `crux` equivalent, except for this one.
