### PR TITLE
crux-smart-open-line-above: Use crux-move-to-mode-line-start

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -246,7 +246,7 @@ Position the cursor at its beginning, according to the current mode."
   (if electric-indent-inhibit
       ;; We can't use `indent-according-to-mode' in languages like Python,
       ;; as there are multiple possible indentations with different meanings.
-      (let* ((indent-end (progn (move-to-mode-line-start) (point)))
+      (let* ((indent-end (progn (crux-move-to-mode-line-start) (point)))
              (indent-start (progn (move-beginning-of-line nil) (point)))
              (indent-chars (buffer-substring indent-start indent-end)))
         (forward-line -1)


### PR DESCRIPTION
After renaming `move-to-mode-line-start` to `crux-move-to-mode-line-start` in https://github.com/bbatsov/crux/commit/dcd693c258ae4d867b18d9a028a828ef6c42a4a6 there are still one usage of old `move-to-mode-line-start` function.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
