### PR TITLE
Read file name insead of raw string

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -411,7 +411,7 @@ there's a region, all lines that region covers will be duplicated."
   (let ((filename (buffer-file-name)))
     (if (not (and filename (file-exists-p filename)))
         (rename-buffer (read-from-minibuffer "New name: " (buffer-name)))
-      (let* ((new-name (read-from-minibuffer "New name: " filename))
+      (let* ((new-name (read-file-name "New name: " (file-name-directory filename)))
              (containing-dir (file-name-directory new-name)))
         (make-directory containing-dir t)
         (cond


### PR DESCRIPTION
Using read-file-name allows completion of file paths while
read-from-minibuffer does not.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
