### PR TITLE
Add crux-recentf-find-directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#65](https://github.com/bbatsov/crux/pull/65): Add a configuration option to move using visual lines in `crux-move-to-mode-line-start`.
 * [#72](https://github.com/bbatsov/crux/pull/72): Add `crux-kill-buffer-truename`. Kills path of file visited by current buffer.
+* [#78](https://github.com/bbatsov/crux/pull/78): Add `crux-recentf-find-directory`. Open recently visited directory.
 
 ### Bugs fixed
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Command                                             | Suggested Keybinding(s)   
 `crux-smart-open-line`                              | <kbd>S-RET</kbd> or <kbd>M-o</kbd> | Insert an empty line and indent it properly (as in most IDEs).
 `crux-cleanup-buffer-or-region`                     | <kbd>C-c n</kbd> | Fix indentation in buffer and strip whitespace.
 `crux-recentf-find-file`                            | <kbd>C-c f</kbd> or <kbd>Super-r</kbd> | Open recently visited file.
+`crux-recentf-find-directory`                       | <kbd>C-c F</kbd> | Open recently visited directory.
 `crux-view-url`                                     | <kbd>C-c u</kbd> | Open a new buffer containing the contents of URL.
 `crux-eval-and-replace`                             | <kbd>C-c e</kbd> | Eval a bit of Emacs Lisp code and replace it with its result.
 `crux-transpose-windows`                            | <kbd>C-x 4 t</kbd> | Transpose the buffers between two windows.

--- a/crux.el
+++ b/crux.el
@@ -606,16 +606,25 @@ as the current user."
   (insert (format-time-string "%c" (current-time))))
 
 ;;;###autoload
-(defun crux-recentf-find-file ()
-  "Find a recent file using `completing-read'."
+(defun crux-recentf-find-file (&optional filter)
+  "Find a recent file using `completing-read'.
+When optional argument FILTER is a function, it is used to
+transform recent files before completion."
   (interactive)
-  (let ((file (completing-read "Choose recent file: "
-                               (mapcar #'abbreviate-file-name recentf-list)
-                               nil t)))
+  (let* ((filter (if (functionp filter) filter #'abbreviate-file-name))
+         (file (completing-read "Choose recent file: "
+                                (delete-dups (mapcar filter recentf-list))
+                                nil t)))
     (when file
       (find-file file))))
 
 (define-obsolete-function-alias 'crux-recentf-ido-find-file 'crux-recentf-find-file "0.4.0")
+
+;;;###autoload
+(defun crux-recentf-find-directory ()
+  "Find a recent directory using `completing-read'."
+  (interactive)
+  (crux-recentf-find-file (lambda (file) (abbreviate-file-name (file-name-directory file)))))
 
 ;; modified from https://www.emacswiki.org/emacs/TransposeWindows
 ;;;###autoload


### PR DESCRIPTION
Adds `crux-recentf-find-directory` for opening recent directories. Complements the existing `crux-recentf-find-file`.

---

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)

