### PR TITLE
More robust `crux-rename-file-and-buffer`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master (unreleased)
+* More robust `crux-rename-file-and-buffer`.
 
 ## 0.4.0 (2021-08-10)
 


### PR DESCRIPTION
Currently if you rename a new buffer that hasn't been saved yet, `crux-rename-file-and-buffer` will only rename the buffer but not reset the visited file name, so saving after renaming will still save to the file name before renaming. The PR also let the user know if we are renaming to an existing buffer.

* Offer to save file first if modified or new unsaved buffer.
* Message user if new file name is the same.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
