### PR TITLE
Ensure `vc-rename-file` gets the local file paths.

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -420,7 +420,11 @@ there's a region, all lines that region covers will be duplicated."
              (containing-dir (file-name-directory new-name)))
         (make-directory containing-dir t)
         (cond
-         ((vc-backend filename) (vc-rename-file filename new-name))
+         ((vc-backend filename)
+          ;; vc-rename-file seems not able to cope with remote filenames?
+          (let ((vc-filename (if (tramp-tramp-file-p filename) (tramp-file-local-name filename) filename))
+                (vc-new-name (if (tramp-tramp-file-p new-name) (tramp-file-local-name filename) new-name)))
+            (vc-rename-file vc-filename vc-new-name)))
          (t
           (rename-file filename new-name t)
           (set-visited-file-name new-name t t)))))))


### PR DESCRIPTION
In `crux-rename-file-and-buffer`, ensure `vc-rename-file` gets only the local file paths -- i.e., that TRAMP prefixes (like `/ssh:foo@example.org:`) are stripped away.

I've seen the Mercurial VC backend error out while `crux-rename-file-and-buffer` on TRAMP filenames.  The source of the error is that `hg mv` gets passed the full Emacs TRAMP file name, which maps to a non-existent file in the Linux filesystem which `hg` sees.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
