### PR TITLE
Add crux-with-region-or-sexp-or-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#94](https://github.com/bbatsov/crux/pull/94): Add `crux-with-region-or-sexp-or-line`.
+
 ## 0.4.0 (2021-08-10)
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ alternately act on the current line if the mark is not active:
 (crux-with-region-or-line comment-or-uncomment-region)
 ```
 
+#### `(crux-with-region-or-sexp-or-line)` ####
+
+Similarly, `crux-with-region-or-sexp-or-line` makes a command that acts on the active region, or else
+the current list (or string), or finally the current line:
+
+```el
+(crux-with-region-or-sexp-or-line kill-region)
+```
+
 #### `(crux-with-region-or-point-to-eol)` ####
 
 Sometimes you might want to act on the point until the end of the

--- a/crux.el
+++ b/crux.el
@@ -797,6 +797,16 @@ and the entire buffer (in the absense of a region)."
           (list (region-beginning) (region-end))
         (list (line-beginning-position) (line-beginning-position 2))))))
 
+(defmacro crux-with-region-or-sexp-or-line (func)
+  "When called with no active region, call FUNC on current sexp/string, or line."
+  `(defadvice ,func (before with-region-or-sexp-or-line activate compile)
+     (interactive
+      (cond
+       (mark-active (list (region-beginning) (region-end)))
+       ((in-string-p) (flatten-list (bounds-of-thing-at-point 'string)))
+       ((thing-at-point 'list) (flatten-list (bounds-of-thing-at-point 'list)))
+       (t (list (line-beginning-position) (line-beginning-position 2)))))))
+
 (defmacro crux-with-region-or-point-to-eol (func)
   "When called with no active region, call FUNC from the point to the end of line."
   `(defadvice ,func (before with-region-or-point-to-eol activate compile)


### PR DESCRIPTION
Similar to the existing macros such as crux-with-region-or-line, add a new macro called crux-with-region-or-sexp-or-line, which advises a command so that if it is called with no active region, it is instead called on the current sexp (or string), falling back to the current line.

Note: I found that some of the functions that might been more obvious to use for this didn't work correctly, e.g. `list-at-point` doesn't work with Clojure vectors and sets (but `(thing-at-point 'list)` handles them fine), and `beginning-of-sexp`/`thing-at-point--beginning-of-sexp` move along a single symbol, but not to the beginning of the list.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
