### PR TITLE
More robust crux-copy-file-preserve-attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * More robust `crux-rename-file-and-buffer`.
 * Fix `sudo` not found error in OpenBSD and Alpine Linux (they use `doas`).
+* More robust `crux-copy-file-preserve-attributes`.
 
 ## 0.4.0 (2021-08-10)
 


### PR DESCRIPTION
`crux-copy-file-preserve-attributes` suffers from several problems:
- A new buffer is always opened without correctly taking into account the value of universal argument
- If filename is different, the new opened buffer contains the source file (destination file in same directory) or an empty buffer (destination file in other directory)
- If the destination chosen by user is a complete path (with filename) in a non-existent directory, the function fails with error "Opening output file: No such file or directory"

So I rewrote the function in a more robust way to to limit mishandled cases.