### PR TITLE
Create nonexistent parent directories in `crux-copy-file-preserve-attributes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Create nonexistent parent directories in `crux-copy-file-preserve-attributes`.
+
 ## 0.5.0 (2024-02-29)
 
 ### New features

--- a/crux.el
+++ b/crux.el
@@ -488,7 +488,7 @@ When invoke with C-u, the newly created file will be visited.
       (unless (or (and dest-dir-missing? (not create-dir?))
                   (and dest-file-exists? (not overwrite-dest-file?)))
         (when (and dest-dir-missing? create-dir?)
-          (make-directory dest-dir))
+          (make-directory dest-dir t))
         (copy-file current-file dest-file overwrite-dest-file? t t t)
         (message "Wrote %s" dest-file)
         (when visit


### PR DESCRIPTION
Just a little fix to complete previous PR (https://github.com/bbatsov/crux/pull/100).
