### PR TITLE
Add crux-find-current-directory-dir-locals-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#101](https://github.com/bbatsov/crux/pull/101): Add `crux-find-current-directory-dir-locals-file`.
+
 ### Bugs fixed
 
 * Create nonexistent parent directories in `crux-copy-file-preserve-attributes`.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Command                                             | Suggested Keybinding(s)   
 `crux-find-user-init-file`                          | <kbd>C-c I</kbd> | Open user's init file.
 `crux-find-user-custom-file`                        | <kbd>C-c ,</kbd> | Open user's custom file.
 `crux-find-shell-init-file`                         | <kbd>C-c S</kbd> | Open shell's init file.
+`crux-find-current-directory-dir-locals-file`       | <kbd>C-c D</kbd> | Open current directory's `.dir-locals.el` file.
 `crux-top-join-line`                                | <kbd>Super-j</kbd> or <kbd>C-^</kbd> | Join lines
 `crux-kill-whole-line`                              | <kbd>Super-k</kbd> | Kill whole line
 `crux-kill-line-backwards`                          | <kbd>C-Backspace</kbd> | Kill line backwards

--- a/crux.el
+++ b/crux.el
@@ -732,6 +732,13 @@ Doesn't mess with special buffers."
       (find-file-other-window (car candidates)))))
 
 ;;;###autoload
+(defun crux-find-current-directory-dir-locals-file ()
+  "Edit the current directory's `.dir-locals.el' file in another window."
+  (interactive)
+  (find-file-other-window
+   (expand-file-name ".dir-locals.el")))
+
+;;;###autoload
 (defun crux-upcase-region (beg end)
   "`upcase-region' when `transient-mark-mode' is on and region is active."
   (interactive "*r")

--- a/crux.el
+++ b/crux.el
@@ -732,11 +732,26 @@ Doesn't mess with special buffers."
       (find-file-other-window (car candidates)))))
 
 ;;;###autoload
-(defun crux-find-current-directory-dir-locals-file ()
-  "Edit the current directory's `.dir-locals.el' file in another window."
-  (interactive)
-  (find-file-other-window
-   (expand-file-name ".dir-locals.el")))
+(defun crux-find-current-directory-dir-locals-file (find-2)
+  "Edit the `.dir-locals.el' file for the current buffer in another window.
+If prefix arg FIND-2 is set then edit the `.dir-locals-2.el' file instead
+of `.dir-locals.el'. Scans parent directories if the file does not exist in
+the default directory of the current buffer. If not found, create a new,
+empty buffer in the current buffer's default directory, or if there is no
+such directory, in the user's home directory."
+  (interactive "P")
+  (let* ((prefix (if (eq system-type 'ms-dos) "_" "."))
+         (file (concat prefix (if find-2 "dir-locals-2" "dir-locals") ".el"))
+         (starting-dir (or (when (and default-directory
+                                      (file-readable-p default-directory))
+                             default-directory)
+                           (file-truename "~/")))
+         (found-dir (or (locate-dominating-file starting-dir file) starting-dir))
+         (found-file (concat found-dir file)))
+    (find-file-other-window found-file)
+    (if (file-exists-p found-file)
+        (message "Editing existing file %s" found-file)
+      (message "Editing new file %s" found-file))))
 
 ;;;###autoload
 (defun crux-upcase-region (beg end)


### PR DESCRIPTION
Response to issue #101. Function creates/edits '.dir-locals.el' file in the current directory of the current buffer.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
