### PR TITLE
Use define-advice instead of defadvice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bugs fixed
 
 * Create nonexistent parent directories in `crux-copy-file-preserve-attributes`.
+* Switch from obsolete `defadvice` to `define-advice`.
 
 ## 0.5.0 (2024-02-29)
 

--- a/crux.el
+++ b/crux.el
@@ -840,37 +840,45 @@ abort completely with `C-g'."
 
 Use to make commands like `indent-region' work on both the region
 and the entire buffer (in the absense of a region)."
-  `(defadvice ,func (before with-region-or-buffer activate compile)
-     (interactive
-      (if mark-active
-          (list (region-beginning) (region-end))
-        (list (point-min) (point-max))))))
+  `(define-advice ,func (:around (orig-fun &rest args) with-region-or-buffer)
+     "Run ORIG-FUN on ARGS if provided, else on the region or entire buffer."
+     (apply orig-fun
+            (cond
+             (args args)
+             (mark-active (list (region-beginning) (region-end)))
+             (t (list (point-min) (point-max)))))))
 
 (defmacro crux-with-region-or-line (func)
   "When called with no active region, call FUNC on current line."
-  `(defadvice ,func (before with-region-or-line activate compile)
-     (interactive
-      (if mark-active
-          (list (region-beginning) (region-end))
-        (list (line-beginning-position) (line-beginning-position 2))))))
+  `(define-advice ,func (:around (orig-fun &rest args) with-region-or-line)
+     "Run ORIG-FUN on ARGS if provided, else on the region or current line."
+     (apply orig-fun
+            (cond
+             (args args)
+             (mark-active (list (region-beginning) (region-end)))
+             (t (list (line-beginning-position) (line-beginning-position 2)))))))
 
 (defmacro crux-with-region-or-sexp-or-line (func)
   "When called with no active region, call FUNC on current sexp/string, or line."
-  `(defadvice ,func (before with-region-or-sexp-or-line activate compile)
-     (interactive
-      (cond
-       (mark-active (list (region-beginning) (region-end)))
-       ((in-string-p) (flatten-list (bounds-of-thing-at-point 'string)))
-       ((thing-at-point 'list) (flatten-list (bounds-of-thing-at-point 'list)))
-       (t (list (line-beginning-position) (line-beginning-position 2)))))))
+  `(define-advice ,func (:around (orig-fun &rest args) with-region-or-sexp-or-line)
+     "Run ORIG-FUN on ARGS if provided, else on the region, or current sexp/string, or line."
+     (apply orig-fun
+            (cond
+             (args args)
+             (mark-active (list (region-beginning) (region-end)))
+             ((in-string-p) (flatten-list (bounds-of-thing-at-point 'string)))
+             ((thing-at-point 'list) (flatten-list (bounds-of-thing-at-point 'list)))
+             (t (list (line-beginning-position) (line-beginning-position 2)))))))
 
 (defmacro crux-with-region-or-point-to-eol (func)
   "When called with no active region, call FUNC from the point to the end of line."
-  `(defadvice ,func (before with-region-or-point-to-eol activate compile)
-     (interactive
-      (if mark-active
-          (list (region-beginning) (region-end))
-        (list (point) (line-end-position))))))
+  `(define-advice ,func (:around (orig-fun &rest args) with-region-or-point-to-eol)
+     "Run ORIG-FUN on ARGS if provided, else on the region, or from point to the end of line."
+     (apply orig-fun
+            (cond
+             (args args)
+             (mark-active (list (region-beginning) (region-end)))
+             (t (list (point) (line-end-position)))))))
 
 (provide 'crux)
 ;;; crux.el ends here


### PR DESCRIPTION
The `defadvice` form is obsolete since Emacs 30.1, which gives warnings during bytecompilation, etc. The alternative is `define-advice`, but that doesn't allow the underlying function's arguments to be altered via `(interactive ...)`, like these `crux-with-region-or-foo` macros were doing. Instead, we can only control the underlying function's arguments if we actually invoke it ourselves, by using `:around` advice (instead of `before` advice). The argument-choosing logic is the same, except we also add the case where we've been given explicit arguments (e.g. if we've been called programatically, rather than interactively).

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
